### PR TITLE
Add macOS build support

### DIFF
--- a/DemoMod.csproj
+++ b/DemoMod.csproj
@@ -22,6 +22,12 @@
     <ModsPath>$(SteamAppsPath)\common\Slay the Spire 2\mods</ModsPath>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+    <SteamAppsPath>$(HOME)/Library/Application Support/Steam/steamapps</SteamAppsPath>
+    <GameDataPath>$(SteamAppsPath)/common/Slay the Spire 2/SlayTheSpire2.app/Contents/Resources/data_sts2_macos_arm64</GameDataPath>
+    <ModsPath>$(SteamAppsPath)/common/Slay the Spire 2/mods</ModsPath>
+  </PropertyGroup>
+
   <!-- Reference the game's own DLLs directly — not copied to output -->
   <ItemGroup>
     <Reference Include="0Harmony">

--- a/README.md
+++ b/README.md
@@ -63,8 +63,20 @@ dotnet build
 ```
 
 构建会自动将 `DemoMod.dll` 复制到 Mod 文件夹：
+
+**Windows:**
 ```
 <Steam>/steamapps/common/Slay the Spire 2/mods/DemoMod/
+```
+
+**macOS:**
+```
+~/Library/Application Support/Steam/steamapps/common/Slay the Spire 2/mods/DemoMod/
+```
+
+macOS 上游戏数据目录（用于 DLL 引用）：
+```
+~/Library/Application Support/Steam/steamapps/common/Slay the Spire 2/SlayTheSpire2.app/Contents/Resources/data_sts2_macos_arm64/
 ```
 
 ### LLM 配置

--- a/README_en.md
+++ b/README_en.md
@@ -63,8 +63,20 @@ dotnet build
 ```
 
 The build automatically copies `DemoMod.dll` to your mods folder:
+
+**Windows:**
 ```
 <Steam>/steamapps/common/Slay the Spire 2/mods/DemoMod/
+```
+
+**macOS:**
+```
+~/Library/Application Support/Steam/steamapps/common/Slay the Spire 2/mods/DemoMod/
+```
+
+Game data directory on macOS (used for DLL references):
+```
+~/Library/Application Support/Steam/steamapps/common/Slay the Spire 2/SlayTheSpire2.app/Contents/Resources/data_sts2_macos_arm64/
 ```
 
 ### LLM Configuration


### PR DESCRIPTION
## Summary

- Add macOS `PropertyGroup` in `DemoMod.csproj` with `~/Library/Application Support/Steam/...` paths
- Document Windows and macOS mod deployment paths in `README.md` and `README_en.md`
- Document macOS game data directory (`data_sts2_macos_arm64`) used for DLL references

## Test plan

- [ ] On macOS, run `dotnet build` and verify `DemoMod.dll` is copied to `~/Library/Application Support/Steam/steamapps/common/Slay the Spire 2/mods/DemoMod/`
- [ ] On Windows, verify existing build behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)